### PR TITLE
運用強化: CI バリデーションとワークフロー失敗通知

### DIFF
--- a/.github/actions/notify-failure/action.yml
+++ b/.github/actions/notify-failure/action.yml
@@ -1,0 +1,37 @@
+name: Notify on failure
+description: >
+  ワークフロー失敗時に GitHub Issue を起票/追記して気づけるようにする。
+  同じワークフローの失敗 Issue が既に open なら重複を作らずコメントを足す。
+
+runs:
+  using: composite
+  steps:
+    - name: Open or update a failure issue
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const title = `⚠️ ワークフロー失敗: ${context.workflow}`;
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const body = [
+            `**${context.workflow}** が失敗しました。`,
+            ``,
+            `- 実行ログ: ${runUrl}`,
+            `- イベント: \`${context.eventName}\``,
+            `- 発生時刻: ${new Date().toISOString()}`,
+          ].join("\n");
+
+          const { owner, repo } = context.repo;
+          const existing = await github.rest.issues.listForRepo({
+            owner, repo, state: "open", labels: "ci-failure", per_page: 100,
+          });
+          const hit = existing.data.find((i) => i.title === title);
+
+          if (hit) {
+            await github.rest.issues.createComment({ owner, repo, issue_number: hit.number, body });
+            core.notice(`Updated existing failure issue #${hit.number}`);
+          } else {
+            const created = await github.rest.issues.create({
+              owner, repo, title, body, labels: ["ci-failure"],
+            });
+            core.notice(`Opened failure issue #${created.data.number}`);
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches-ignore: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compile scripts
+        run: python -m py_compile scripts/*.py
+
+      - name: Validate docs and generators
+        run: python scripts/validate.py

--- a/.github/workflows/update-ics.yml
+++ b/.github/workflows/update-ics.yml
@@ -31,6 +31,8 @@ jobs:
         env:
           FEEDS_YML: feeds.yml
           OUT_DIR: docs
+          # 未設定なら空文字 → スクリプトが Atom 方式に自動フォールバックする。
+          CONNPASS_API_KEY: ${{ secrets.CONNPASS_API_KEY }}
         run: python scripts/generate_all_ics.py
 
       - name: Commit if changed

--- a/.github/workflows/update-ics.yml
+++ b/.github/workflows/update-ics.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: update-ics-feeds
@@ -43,3 +44,7 @@ jobs:
           else
             echo "No changes."
           fi
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure

--- a/.github/workflows/update-issues-ics.yml
+++ b/.github/workflows/update-issues-ics.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: write
-  issues: read
+  issues: write
 
 concurrency:
   group: update-issues-ics
@@ -48,3 +48,7 @@ jobs:
           else
             echo "No changes."
           fi
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # shimajima-eiji.github.io
-GHPルート
+
+GitHub Pages のルート。`docs/` を公開している。
+
+- 公開ページ: https://shimajima-eiji.github.io/
+  - トップ … カレンダー購読 (ICS) 一覧
+  - `/apps.html` … AI で作ったミニアプリ集
+
+## カレンダー (ICS) 配信
+
+| ファイル | 中身 | 生成 |
+|----------|------|------|
+| `docs/{key}.ics` | connpass グループのイベント | `update-ics.yml`（毎日 + 手動） |
+| `docs/github-issues.ics` | Issue 本文の `due:` を締切予定に | `update-issues-ics.yml`（毎日 + Issue 変更時） |
+| `docs/feeds.json` | トップページが読む connpass 一覧 | 上記と同時生成 |
+
+### connpass グループを増やす
+
+`feeds.yml` に追記するだけ。ICS 生成もトップページ掲載も自動で追従する。
+
+```yaml
+  - key: jawsug-tokyo          # 配信ファイル名 → /jawsug-tokyo.ics
+    name: "JAWS-UG Tokyo"
+    subdomain: "jawsug-tokyo"  # {subdomain}.connpass.com
+```
+
+### Issue に締切を付ける
+
+Issue 本文のどこかに `due: 2026-07-01` と書くと、終日予定として配信される（過去日は自動除外）。
+
+### connpass の取得方式（Atom / API v2）
+
+- 既定は **Atom 方式**（API キー不要・直近数件）。
+- リポジトリ Secret `CONNPASS_API_KEY` を設定すると **API v2** に切り替わり、今月〜数ヶ月先のイベントをまとめて取得する。キーが無い／取得失敗時は自動で Atom にフォールバックする。
+- API キーは connpass の公式サポートへの申請で取得する。
+
+## 開発
+
+```sh
+python scripts/generate_all_ics.py     # connpass ICS + feeds.json
+python scripts/generate_issues_ics.py  # Issues ICS（GH_TOKEN / GITHUB_REPOSITORY が必要）
+python scripts/validate.py             # 静的検査 + 自己テスト（CI と同じ）
+```
+
+CI（`ci.yml`）は PR と `main` 以外への push で `validate.py` を実行する。
+スケジュールジョブが失敗すると `ci-failure` ラベルの Issue が自動で起票される。

--- a/scripts/generate_all_ics.py
+++ b/scripts/generate_all_ics.py
@@ -24,15 +24,18 @@ import json
 import os
 import re
 import sys
+import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from zoneinfo import ZoneInfo
 from typing import Any, Dict, List, Optional
 
 JST = ZoneInfo("Asia/Tokyo")
 ATOM_NS = "http://www.w3.org/2005/Atom"
+USER_AGENT = "connpass-ics-generator/2.0 (+https://github.com/shimajima-eiji/shimajima-eiji.github.io)"
+CONNPASS_API_URL = "https://connpass.com/api/v2/events/"
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +164,7 @@ def fetch_atom(subdomain: str) -> List[CalEvent]:
     """
     url = f"https://{subdomain}.connpass.com/ja.atom"
     req = urllib.request.Request(url, method="GET")
-    req.add_header("User-Agent", "connpass-ics-generator/2.0")
+    req.add_header("User-Agent", USER_AGENT)
 
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
@@ -211,6 +214,85 @@ def fetch_atom(subdomain: str) -> List[CalEvent]:
             summary=summary,
         ))
 
+    return events
+
+
+# ---------------------------------------------------------------------------
+# connpass API v2 取得（CONNPASS_API_KEY がある場合のみ使用）
+#   - 認証: X-API-Key ヘッダ。User-Agent 必須。
+#   - ym(年月) で「今月〜数ヶ月先」に絞り、過去イベントで埋まるのを防ぐ。
+#   - キーが無い／失敗した場合は呼び出し側で Atom にフォールバックする。
+# ---------------------------------------------------------------------------
+
+def _ym_window(months_ahead: int = 6) -> List[str]:
+    """今月から months_ahead ヶ月先までの YYYYMM 文字列リストを返す。"""
+    today = date.today()
+    out: List[str] = []
+    y, m = today.year, today.month
+    for _ in range(months_ahead + 1):
+        out.append(f"{y}{m:02d}")
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+    return out
+
+
+def event_from_api(e: Dict[str, Any]) -> CalEvent:
+    """connpass API v2 のイベント1件を CalEvent に変換する（純粋関数）。"""
+    title = (e.get("title") or "").strip()
+    url_href = (e.get("event_url") or "").strip()
+    event_id = e.get("event_id")
+    uid = f"connpass-event-{event_id}@connpass.com" if event_id else url_href
+
+    started_at = parse_iso_datetime(e.get("started_at") or "")
+    ended_raw = e.get("ended_at")
+    if ended_raw:
+        ended_at = parse_iso_datetime(ended_raw)
+    else:
+        ended_at = started_at.replace(hour=min(started_at.hour + 1, 23))
+    if ended_at <= started_at:
+        ended_at = started_at.replace(hour=min(started_at.hour + 1, 23))
+
+    catch = (e.get("catch") or "").strip()
+    place = (e.get("place") or "").strip()
+    summary = "\n".join(p for p in [catch, (f"会場: {place}" if place else "")] if p)
+
+    return CalEvent(
+        uid=uid,
+        title=title,
+        url=url_href,
+        published=started_at,
+        started_at=started_at,
+        ended_at=ended_at,
+        summary=summary,
+    )
+
+
+def fetch_api(subdomain: str, api_key: str, months_ahead: int = 6, count: int = 100) -> List[CalEvent]:
+    """connpass API v2 から今後のイベントを取得する。失敗時は例外を送出する。"""
+    params: List[tuple[str, str]] = [
+        ("subdomain", subdomain),
+        ("count", str(count)),
+        ("order", "2"),  # 開催日時順
+    ]
+    params += [("ym", ym) for ym in _ym_window(months_ahead)]
+    url = f"{CONNPASS_API_URL}?{urllib.parse.urlencode(params)}"
+
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("X-API-Key", api_key)
+    req.add_header("User-Agent", USER_AGENT)
+    req.add_header("Accept", "application/json")
+
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+
+    events: List[CalEvent] = []
+    for e in data.get("events", []) or []:
+        try:
+            events.append(event_from_api(e))
+        except Exception:  # noqa: BLE001 — 不正な1件はスキップ
+            continue
     return events
 
 
@@ -319,6 +401,9 @@ def main() -> int:
     if not feeds:
         die("feeds.yml に feeds がありません。")
 
+    api_key = os.getenv("CONNPASS_API_KEY", "").strip()
+    print(f"connpass source: {'API v2 (key あり)' if api_key else 'Atom (key なし)'}")
+
     total = 0
     generated: List[Dict[str, Any]] = []
     for feed in feeds:
@@ -330,16 +415,26 @@ def main() -> int:
             print(f"SKIP {key}: subdomain 未指定", file=sys.stderr)
             continue
 
-        events = fetch_atom(subdomain)
+        # API キーがあれば API v2、無ければ／失敗時は Atom を使う。
+        source = "atom"
+        if api_key:
+            try:
+                events = fetch_api(subdomain, api_key)
+                source = "api"
+            except Exception as ex:  # noqa: BLE001
+                print(f"WARN {key}: API 取得失敗のため Atom にフォールバック: {ex}", file=sys.stderr)
+                events = fetch_atom(subdomain)
+        else:
+            events = fetch_atom(subdomain)
 
         ics = build_ics(events, cal_name=name)
         out_path = os.path.join(out_dir, f"{key}.ics")
         with open(out_path, "w", encoding="utf-8", newline="") as f:
             f.write(ics)
 
-        print(f"OK  {key}: {len(events)} events -> {out_path}")
+        print(f"OK  {key}: {len(events)} events [{source}] -> {out_path}")
         total += len(events)
-        generated.append({"key": key, "name": name, "events": len(events)})
+        generated.append({"key": key, "name": name, "events": len(events), "source": source})
 
     # トップページ（index.html）が動的に読み込む一覧。
     # feeds.yml を更新すれば自動で追従し、HTML を手で直す必要がない。

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -168,6 +168,23 @@ def selftest_connpass() -> None:
     assert ics.startswith("BEGIN:VCALENDAR\r\n")
     assert ics.rstrip("\r\n").endswith("END:VCALENDAR")
     assert ics.count("BEGIN:VEVENT") == 1
+
+    # API v2 レスポンス1件 → CalEvent 変換（ネットワーク不要）
+    api_ev = gen.event_from_api({
+        "title": "もくもく会",
+        "event_id": 365530,
+        "event_url": "https://ospn.connpass.com/event/365530/",
+        "started_at": "2025-08-16T07:00:00+09:00",
+        "ended_at": "2025-08-16T08:00:00+09:00",
+        "place": "Discord",
+        "catch": "ゆるい会",
+    })
+    assert api_ev.uid == "connpass-event-365530@connpass.com"
+    assert api_ev.started_at.hour == 7 and api_ev.ended_at.hour == 8
+    assert "会場: Discord" in api_ev.summary
+    # ym ウィンドウは今月を含み months_ahead+1 件
+    win = gen._ym_window(6)
+    assert len(win) == 7 and len(win[0]) == 6
     ok("selftest generate_all_ics")
 
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+docs/ と scripts/ の最小バリデーション（ネットワーク不要・CI 用）。
+
+目的:
+    壊れた HTML / ICS / JSON が GitHub Pages に公開されるのを防ぐ。
+    外部 API を叩かず、生成ロジックの自己テストと静的ファイル検査だけを行う。
+
+使い方:
+    python scripts/validate.py
+"""
+
+from __future__ import annotations
+
+import glob
+import importlib.util
+import json
+import os
+import sys
+from datetime import datetime
+from html.parser import HTMLParser
+from zoneinfo import ZoneInfo
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DOCS = os.path.join(ROOT, "docs")
+JST = ZoneInfo("Asia/Tokyo")
+
+errors: list[str] = []
+
+
+def err(msg: str) -> None:
+    errors.append(msg)
+    print(f"  NG  {msg}")
+
+
+def ok(msg: str) -> None:
+    print(f"  OK  {msg}")
+
+
+# ---------------------------------------------------------------------------
+# HTML 検査
+# ---------------------------------------------------------------------------
+
+# 明示的に開閉するコンテナ系タグだけ釣り合いを検査する（p/li 等の省略可能タグは対象外）。
+_TRACKED = {"html", "head", "body", "div", "nav", "header", "footer", "ul", "script", "style"}
+
+
+class _Counter(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.starts: dict[str, int] = {}
+        self.ends: dict[str, int] = {}
+
+    def handle_starttag(self, tag, attrs):
+        if tag in _TRACKED:
+            self.starts[tag] = self.starts.get(tag, 0) + 1
+
+    def handle_endtag(self, tag):
+        if tag in _TRACKED:
+            self.ends[tag] = self.ends.get(tag, 0) + 1
+
+
+def check_html(path: str) -> None:
+    name = os.path.relpath(path, ROOT)
+    with open(path, encoding="utf-8") as f:
+        html = f.read()
+
+    c = _Counter()
+    c.feed(html)
+    c.close()
+
+    for tag in _TRACKED:
+        s, e = c.starts.get(tag, 0), c.ends.get(tag, 0)
+        if s != e:
+            err(f"{name}: <{tag}> の開閉数が不一致 (open={s}, close={e})")
+
+    low = html.lower()
+    for must in ("<!doctype html", "<title>", "</html>", "</body>"):
+        if must not in low:
+            err(f"{name}: 必須要素が見つからない: {must}")
+
+    if not errors or all(name not in x for x in errors):
+        ok(f"HTML {name}")
+
+
+# ---------------------------------------------------------------------------
+# ICS / JSON 検査
+# ---------------------------------------------------------------------------
+
+def check_ics(path: str) -> None:
+    name = os.path.relpath(path, ROOT)
+    # newline="" で改行変換を抑止し、実際の CRLF を検査できるようにする。
+    with open(path, encoding="utf-8", newline="") as f:
+        body = f.read()
+    problems = []
+    if not body.startswith("BEGIN:VCALENDAR"):
+        problems.append("BEGIN:VCALENDAR で始まっていない")
+    if not body.rstrip("\r\n").endswith("END:VCALENDAR"):
+        problems.append("END:VCALENDAR で終わっていない")
+    if "\r\n" not in body:
+        problems.append("CRLF 改行になっていない")
+    if body.count("BEGIN:VEVENT") != body.count("END:VEVENT"):
+        problems.append("VEVENT の開閉数が不一致")
+    for p in problems:
+        err(f"{name}: {p}")
+    if not problems:
+        ok(f"ICS  {name}")
+
+
+def check_json(path: str) -> None:
+    name = os.path.relpath(path, ROOT)
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as e:  # noqa: BLE001
+        err(f"{name}: JSON として不正: {e}")
+        return
+    if "feeds" not in data or not isinstance(data["feeds"], list):
+        err(f"{name}: 'feeds' 配列がない")
+    else:
+        ok(f"JSON {name} ({len(data['feeds'])} feeds)")
+
+
+# ---------------------------------------------------------------------------
+# 生成ロジックの自己テスト（ネットワーク不要）
+# ---------------------------------------------------------------------------
+
+def _load(module_name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(
+        module_name, os.path.join(ROOT, "scripts", filename)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # dataclass などが __module__ を解決できるよう先に登録する。
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def selftest_connpass() -> None:
+    gen = _load("gen_all_ics", "generate_all_ics.py")
+
+    # ICS エスケープ
+    assert gen.ics_escape("a,b;c\\d\ne") == "a\\,b\\;c\\\\d\\ne"
+
+    # 行折り返しは UTF-8 75 バイト以内
+    long_line = "X" * 200
+    for piece in gen.ics_fold_line(long_line):
+        assert len(piece.encode("utf-8")) <= 75
+
+    # 開催日時パース
+    summary = "開催日時: 2026/04/18 10:00 ～ 18:00 / 場所: ..."
+    fallback = datetime(2026, 1, 1, tzinfo=JST)
+    started, ended = gen.parse_event_datetime(summary, fallback)
+    assert (started.hour, ended.hour) == (10, 18), (started, ended)
+
+    # build_ics の構造
+    ev = gen.CalEvent(
+        uid="uid-1",
+        title="テスト, イベント",
+        url="https://ospn.connpass.com/event/1/",
+        published=fallback,
+        started_at=started,
+        ended_at=ended,
+        summary=summary,
+    )
+    ics = gen.build_ics([ev], "テストカレンダー")
+    assert ics.startswith("BEGIN:VCALENDAR\r\n")
+    assert ics.rstrip("\r\n").endswith("END:VCALENDAR")
+    assert ics.count("BEGIN:VEVENT") == 1
+    ok("selftest generate_all_ics")
+
+
+def selftest_issues() -> None:
+    iss = _load("gen_issues_ics", "generate_issues_ics.py")
+    import datetime as _dt
+
+    assert iss.extract_due("foo\ndue: 2026-03-15\nbar") == _dt.date(2026, 3, 15)
+    assert iss.extract_due("due なし") is None
+    assert iss.extract_due("DUE : 2026-12-31") == _dt.date(2026, 12, 31)
+    ok("selftest generate_issues_ics")
+
+
+# ---------------------------------------------------------------------------
+# エントリポイント
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    print("== HTML ==")
+    for path in sorted(glob.glob(os.path.join(DOCS, "*.html"))):
+        check_html(path)
+
+    print("== ICS ==")
+    for path in sorted(glob.glob(os.path.join(DOCS, "*.ics"))):
+        check_ics(path)
+
+    print("== JSON ==")
+    for path in sorted(glob.glob(os.path.join(DOCS, "*.json"))):
+        check_json(path)
+
+    print("== 自己テスト ==")
+    selftest_connpass()
+    selftest_issues()
+
+    print("---")
+    if errors:
+        print(f"FAILED: {len(errors)} 件のエラー", file=sys.stderr)
+        return 1
+    print("PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要

運用改善「全部やろう」の **3点すべて** を実装しました。

### ✅ ① CI バリデーション（壊れたページの公開を防ぐ）
- `scripts/validate.py`（ネットワーク不要）を追加
  - `docs/*.html` … コンテナタグの開閉数・必須要素を検査
  - `docs/*.ics` … `BEGIN/END:VCALENDAR`・CRLF・`VEVENT` を検査
  - `docs/feeds.json` … JSON 妥当性を検査
  - 生成ロジック（escape / 行折返し / 開催日時パース / `build_ics` / `event_from_api` / `extract_due`）を自己テスト
- `.github/workflows/ci.yml` … PR と `main` 以外への push で `py_compile` + `validate.py`

### ✅ ② ワークフロー失敗通知（黙って失敗しない）
- `.github/actions/notify-failure` 複合アクション
  - 失敗時に `ci-failure` ラベルの Issue を起票。同一ワークフローの open Issue があれば重複せずコメント追記
- `update-ics.yml` / `update-issues-ics.yml` に `if: failure()` を追加し `issues: write` を付与

### ✅ ③ connpass API v2 対応（キーありで多件数取得）
- `generate_all_ics.py` に API v2 取得を追加
  - Secret `CONNPASS_API_KEY` があれば API v2（`X-API-Key` 認証）で **今月〜6ヶ月先** を取得
  - `ym` パラメータで期間を絞り、過去イベントで埋まるのを防止
  - **キーが無い／API 失敗時は Atom 方式へ自動フォールバック**（現状の挙動を維持）
  - `feeds.json` に `source`(api/atom) を記録
- `update-ics.yml` にシークレットを受け渡し

> API キーを使うには、connpass 公式サポートでキーを取得し、リポジトリ Secret `CONNPASS_API_KEY` に登録してください。未登録のままでも Atom 方式で動作します。

## 確認
- `python scripts/validate.py` → 全項目 PASSED
- キー無しで `generate_all_ics.py` 実行 → `[atom]` で 10 件取得・正常フォールバックを確認
- `python -m py_compile scripts/*.py` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKQtEmxGeEuMhmmDPXe1bB